### PR TITLE
Dynamic CustomId slugs

### DIFF
--- a/src/buttons/testing-button-with-id-[id].ts
+++ b/src/buttons/testing-button-with-id-[id].ts
@@ -1,0 +1,16 @@
+import Button from 'classes/Button';
+import { ButtonInteraction } from 'discord.js';
+import ExtendedClient from 'classes/ExtendedClient';
+
+export default class TestingButtonWithId extends Button {
+  public async execute(
+    client: ExtendedClient,
+    interaction: ButtonInteraction,
+    pathData: { id: string }
+  ): Promise<void> {
+    await interaction.reply({
+      content: `> ${pathData.id}`,
+      ephemeral: true,
+    });
+  }
+}

--- a/src/classes/Button.ts
+++ b/src/classes/Button.ts
@@ -7,7 +7,11 @@ export default abstract class Button {
     this.customId = customId;
   }
 
-  public execute(client: ExtendedClient, interaction: ButtonInteraction): void {
+  public execute(
+    client: ExtendedClient,
+    interaction: ButtonInteraction,
+    pathData?: { [slug: string]: string }
+  ): void {
     client.logger.warn(
       `Button ${interaction.customId} is missing execute() method`
     );

--- a/src/classes/Modal.ts
+++ b/src/classes/Modal.ts
@@ -9,7 +9,8 @@ export default abstract class Modal {
 
   public execute(
     client: ExtendedClient,
-    interaction: ModalSubmitInteraction
+    interaction: ModalSubmitInteraction,
+    pathData?: { [slug: string]: string }
   ): void {
     client.logger.warn(
       `Button ${interaction.customId} is missing execute() method`

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -3,57 +3,41 @@ import {
   SlashCommandBuilder,
   CommandInteraction,
   CacheType,
-  CommandInteractionOptionResolver,
   ActionRowBuilder,
   ButtonBuilder,
   ButtonStyle,
-  ActionRowData,
 } from 'discord.js';
 import ExtendedClient from 'classes/ExtendedClient';
 
-export default class Echo extends Command {
+export default class Test extends Command {
   constructor(name: string) {
     super(name);
   }
 
+  description = 'Testing dynamic CustomId buttons';
+
   get data(): Partial<SlashCommandBuilder> {
     return new SlashCommandBuilder()
       .setName(this.name)
-      .setDescription('Echoes your message (example command)')
-      .addStringOption((option) =>
-        option
-          .setName('message')
-          .setDescription('The message to echo')
-          .setRequired(true)
-      );
+      .setDescription(this.description);
   }
 
   public async execute(
     client: ExtendedClient,
     interaction: CommandInteraction<CacheType>
   ): Promise<void> {
-    const message = (
-      interaction.options as CommandInteractionOptionResolver<CacheType>
-    ).getString('message');
-
-    if (!message) {
-      interaction.reply({
-        content: '> :warning: | Please provide a message to echo',
-        ephemeral: true,
-      });
-      return;
-    }
+    const random = Math.random();
 
     const row = new ActionRowBuilder().addComponents(
       new ButtonBuilder()
-        .setCustomId('echo-open-modal')
-        .setLabel('Open modal')
+        .setCustomId(`testing-button-with-id-${random}`)
+        .setLabel(`Testing button with id ${random}`)
         .setStyle(ButtonStyle.Primary)
     );
 
     await interaction.reply({
-      content: `> :information_source: ${message}`,
       components: [row as any],
+      content: 'Click button',
       ephemeral: true,
     });
   }

--- a/src/events/InteractionCreate.ts
+++ b/src/events/InteractionCreate.ts
@@ -9,6 +9,9 @@ import CommandNotFoundException from 'exceptions/CommandNotFoundException';
 import ButtonNotFoundException from 'exceptions/ButtonNotFoundException';
 import ModalNotFoundException from 'exceptions/ModalNotFoundException';
 import Exception from 'exceptions/Exception';
+import dynamicCustomIdFinder from 'utils/dynamicCustomIdFinder';
+import Button from 'classes/Button';
+import Modal from 'classes/Modal';
 
 export default class InteractionCreate extends DiscordEvent {
   public once = false;
@@ -30,7 +33,8 @@ export default class InteractionCreate extends DiscordEvent {
         });
       }
     } else if (interaction.isButton()) {
-      const button = client.buttons.get(
+      const [button, pathData] = dynamicCustomIdFinder(
+        client.buttons,
         (interaction as ButtonInteraction).customId
       );
 
@@ -40,7 +44,11 @@ export default class InteractionCreate extends DiscordEvent {
         );
 
       try {
-        button.execute(client, interaction as ButtonInteraction);
+        (button as Button).execute(
+          client,
+          interaction as ButtonInteraction,
+          pathData
+        );
       } catch (error) {
         const exception = error as Exception;
         client.logger.error(error);
@@ -50,7 +58,8 @@ export default class InteractionCreate extends DiscordEvent {
         });
       }
     } else if (interaction.isModalSubmit()) {
-      const modal = client.modals.get(
+      const [modal, pathData] = dynamicCustomIdFinder(
+        client.buttons,
         (interaction as ModalSubmitInteraction).customId
       );
 
@@ -60,7 +69,11 @@ export default class InteractionCreate extends DiscordEvent {
         );
 
       try {
-        modal.execute(client, interaction as ModalSubmitInteraction);
+        (modal as Modal).execute(
+          client,
+          interaction as ModalSubmitInteraction,
+          pathData
+        );
       } catch (error) {
         const exception = error as Exception;
         client.logger.error(error);

--- a/src/modals/echo-modal.ts
+++ b/src/modals/echo-modal.ts
@@ -11,6 +11,7 @@ export default class EchoModal extends Modal {
       content: `> :information_source: Modal response: ${interaction.fields.getTextInputValue(
         'echo-modal-text-input'
       )}`,
+      ephemeral: true,
     });
   }
 }

--- a/src/utils/dynamicCustomIdFinder.ts
+++ b/src/utils/dynamicCustomIdFinder.ts
@@ -1,0 +1,47 @@
+import Button from 'classes/Button';
+import Modal from 'classes/Modal';
+import { Collection } from 'discord.js';
+
+/**
+ * @param route The custom id of the button or modal. It can include dynamic parts. e.g. "support-close-[id]"
+ */
+export default (
+  collection: Collection<string, Modal | Button>,
+  route: string
+): [Modal | Button | null, { [slug: string]: string }?] => {
+  const exactMatch = collection.get(route);
+  if (exactMatch) return [exactMatch];
+
+  let returnItem: Modal | Button | null = null;
+  let returnPathData: { [slug: string]: string } | undefined = undefined;
+
+  collection.forEach((item: Modal | Button) => {
+    if (returnItem) return;
+    const customId = item.customId;
+    const customIdParts = customId.split('-');
+    const routeParts = route.split('-');
+
+    if (customIdParts.length !== routeParts.length) return;
+
+    let match = true;
+    const pathData: { [slug: string]: string } = {};
+
+    for (let i = 0; i < customIdParts.length; i++) {
+      if (customIdParts[i] === routeParts[i]) continue;
+      if (customIdParts[i].startsWith('[') && customIdParts[i].endsWith(']')) {
+        pathData[customIdParts[i].slice(1, -1)] = routeParts[i];
+        continue;
+      }
+
+      match = false;
+      break;
+    }
+
+    if (match) {
+      returnItem = item;
+      returnPathData = pathData;
+    }
+  });
+
+  return [returnItem, returnPathData];
+};


### PR DESCRIPTION
Supports dynamic buttons/modal custom ids. 

You can specify a dynamic route by using `[slug]` in the file name. 

E.g.
`support-close-[ticketId].ts`
You could then reference it by adding a custom ID to a button for example `support-close-2321`.

You can also access the data via the `pathData` argument in the `execute()` method of any button/modal.